### PR TITLE
update schema

### DIFF
--- a/src/database/schema.prisma
+++ b/src/database/schema.prisma
@@ -31,7 +31,7 @@ model Notification {
 model Link {
   id                 String         @id @default(uuid())
   notificationId     String         @unique
-  notification       Notification   @relation(fields: [notificationId], references: [id])
+  notification       Notification   @relation(fields: [notificationId], references: [id], onDelete: Cascade) //This would save us all those if checks when truying to delete a notification object
   facebook           String?
   instagram          String?
   twitter            String?

--- a/src/modules/admins/decorators/matches-with.decorator.ts
+++ b/src/modules/admins/decorators/matches-with.decorator.ts
@@ -10,7 +10,7 @@ export function MatchesWith(
 ) {
   return function (object: object, propertyName: string) {
     registerDecorator({
-      name: 'isLongerThan',
+      name: 'MatchesWith',
       target: object.constructor,
       propertyName: propertyName,
       constraints: [property],


### PR DESCRIPTION
I modified the schema so that we do not have to do all those if checks when deleting the notification. Deleting the notification automatically deletes the Link.

The way it currently is, we have to first delete the Link before deleting the notification. If we try it the other way, prisma complains.